### PR TITLE
Get rid of APIKEY, create download dir if its is missing

### DIFF
--- a/examples/fmiopendata-client/python/fmiopendata
+++ b/examples/fmiopendata-client/python/fmiopendata
@@ -52,12 +52,6 @@ Examples:
         proxy_host = None
         proxy_port = None
 
-    try:
-        apikey = os.environ['fmi_apikey']
-    except:
-        print "Put following environment variables to your environment:"
-        print "  export fmi_apikey=xxx"
-        sys.exit(2)
 
     verbose = False
     if args.verbose is not None:
@@ -70,25 +64,25 @@ Examples:
     # Execute
     if args.what[0] == 'stored_queries':
         try:
-            fmiod.get_storedqueries(apikey, args.format)
+            fmiod.get_storedqueries(args.format)
         except (UnboundLocalError):
             sys.exit(2)
     elif args.what[0] == 'data':
         try:
-            fmiod.print_positions(*fmiod.get_data(apikey, args.stored_query, args.bbox, args.starttime, args.endtime))
+            fmiod.print_positions(*fmiod.get_data(args.stored_query, args.bbox, args.starttime, args.endtime))
         except UnboundLocalError as e:
             print e
             sys.exit(2)
     elif args.what[0] == 'parameters':
         try:
-            data, params = fmiod.get_data(apikey, args.stored_query, args.bbox, args.starttime, args.endtime)
+            data, params = fmiod.get_data(args.stored_query, args.bbox, args.starttime, args.endtime)
             fmiod.print_parameters(params)
         except UnboundLocalError as e:
             print e
             sys.exit(2)
     elif args.what[0] == 'coverages':
         try:
-            files = fmiod.get_files(apikey, args.stored_query, args.bbox, args.starttime, args.endtime, args.file_prefix, args.file_format)
+            files = fmiod.get_files(args.stored_query, args.bbox, args.starttime, args.endtime, args.file_prefix, args.file_format)
 
             if verbose or args.dir is None:
                 io.print_files(files)

--- a/examples/fmiopendata-client/python/fmiopendatahelper/fmiopendata.py
+++ b/examples/fmiopendata-client/python/fmiopendatahelper/fmiopendata.py
@@ -30,9 +30,9 @@ class FMIOpenData:
         self.params = params
         return params
 
-    def do_req(self, apikey, stored_query, bbox, firstdate, lastdate):
+    def do_req(self, stored_query, bbox, firstdate, lastdate):
         """ Do data request """
-        url = 'http://data.fmi.fi/fmi-apikey/' + apikey + '/wfs?request=getFeature&storedquery_id='+stored_query
+        url = 'http://opendata.fmi.fi/wfs?request=getFeature&storedquery_id='+stored_query
         try:
             url += '&bbox='+bbox
         except:
@@ -83,10 +83,10 @@ class FMIOpenData:
 
         return time
             
-    def get_files(self, apikey, stored_query, bbox, firstdate, lastdate, file_prefix, file_format):
+    def get_files(self, stored_query, bbox, firstdate, lastdate, file_prefix, file_format):
         """ Get downloadable coverages """
 
-        req = self.do_req(apikey, stored_query, bbox, firstdate, lastdate)
+        req = self.do_req(stored_query, bbox, firstdate, lastdate)
         if req.status_code == 200:
             xmlstring = req.content
             tree = ET.ElementTree(ET.fromstring(xmlstring))
@@ -189,10 +189,10 @@ class FMIOpenData:
                     if p != 'time' and value != 'NaN':
                         print '  '+params[p],value
 
-    def get_data(self, apikey,stored_query,bbox,firstdate,lastdate):
+    def get_data(self, stored_query,bbox,firstdate,lastdate):
         """ Get data """
 
-        req = self.do_req(apikey, stored_query, bbox, firstdate, lastdate)
+        req = self.do_req(stored_query, bbox, firstdate, lastdate)
     
         if req.status_code == 200:
             xmlstring = req.content
@@ -201,10 +201,10 @@ class FMIOpenData:
             
         return positions, params
 
-    def get_storedqueries(self, apikey, format=''):
+    def get_storedqueries(self, format=''):
         """ Print stored queries """
         
-        url='http://data.fmi.fi/fmi-apikey/' + apikey + '/wfs?request=listStoredQueries'
+        url='http://opendata.fmi.fi/wfs?request=listStoredQueries'
 
         if self.verbose:
             print "Fetching stored queries from ",url

--- a/examples/fmiopendata-client/python/fmiopendatahelper/fmiopendataio.py
+++ b/examples/fmiopendata-client/python/fmiopendatahelper/fmiopendataio.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 import requests
-from os import listdir
+from os import listdir, mkdir
 from os.path import isfile, join
 
 
@@ -43,7 +43,12 @@ class FMIOpenDataIO:
     def fill_dir(self, files, dir):
         """ Mirror files got from WFS response and in given directory """
         
-        existing_files = [f for f in listdir(dir) if isfile(join(dir, f))]
+        print "dir " + dir
+        existing_files = []
+        try:
+            existing_files = [f for f in listdir(dir) if isfile(join(dir, f))]
+        except:
+            mkdir(dir)
         available_files = files.keys()
 
         to_download = list(set(available_files) - set(existing_files))

--- a/examples/fmiopendata-client/python/fmiopendatahelper/fmiopendataio.py
+++ b/examples/fmiopendata-client/python/fmiopendatahelper/fmiopendataio.py
@@ -11,9 +11,9 @@ class FMIOpenDataIO:
     def set_verbose(self, verbose=True):
         self.verbose = verbose
 
-    def do_req(self, apikey, stored_query, bbox, firstdate, lastdate):
+    def do_req(self, stored_query, bbox, firstdate, lastdate):
         """ Do data request """
-        url = 'http://data.fmi.fi/fmi-apikey/' + apikey + '/wfs?request=getFeature&storedquery_id='+stored_query
+        url = 'http://opendata.fmi.fi/wfs?request=getFeature&storedquery_id='+stored_query
         try:
             url += '&bbox='+bbox
         except:


### PR DESCRIPTION
In first commit, get rid if apikey, use new url instead the old one which require the apikey.

Second commit, create download directory if it is missing instead of bailing out with OSError.

I tested these changes with the few example command lines which you can see with command fmioendata --help. I'm not sure if these is some bigger test set I should run.